### PR TITLE
Bump package versions to 2.1.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ group=io.ballerina.lib
 
 # This is a dummy value as repo contains multiple packages
 version=2.1.0-SNAPSHOT
-api_salesdistrict_srvVersion=2.0.0-SNAPSHOT
-api_salesorganization_srvVersion=2.0.0-SNAPSHOT
-api_sales_order_srvVersion=2.0.0-SNAPSHOT
-api_sd_sa_soldtopartydetnVersion=2.0.0-SNAPSHOT
-salesarea_0001Version=2.0.0-SNAPSHOT
-api_sd_incoterms_srvVersion=2.0.0-SNAPSHOT
-api_sales_inquiry_srvVersion=2.0.0-SNAPSHOT
-api_sales_quotation_srvVersion=2.0.0-SNAPSHOT
-api_sales_order_simulation_srvVersion=2.0.0-SNAPSHOT
-ce_salesorder_0001Version=2.0.0-SNAPSHOT
+api_salesdistrict_srvVersion=2.1.0-SNAPSHOT
+api_salesorganization_srvVersion=2.1.0-SNAPSHOT
+api_sales_order_srvVersion=2.1.0-SNAPSHOT
+api_sd_sa_soldtopartydetnVersion=2.1.0-SNAPSHOT
+salesarea_0001Version=2.1.0-SNAPSHOT
+api_sd_incoterms_srvVersion=2.1.0-SNAPSHOT
+api_sales_inquiry_srvVersion=2.1.0-SNAPSHOT
+api_sales_quotation_srvVersion=2.1.0-SNAPSHOT
+api_sales_order_simulation_srvVersion=2.1.0-SNAPSHOT
+ce_salesorder_0001Version=2.1.0-SNAPSHOT
 
 ballerinaGradlePluginVersion=2.3.0
 downloadPluginVersion=5.4.0


### PR DESCRIPTION
## Summary
- Bump all individual package versions from `2.0.0-SNAPSHOT` to `2.1.0-SNAPSHOT` in `gradle.properties`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Updates build configuration to advance snapshot versions for the SAP S/4HANA Sales module library from version 2.0.0-SNAPSHOT to 2.1.0-SNAPSHOT in preparation for the next development cycle.

## Changes
Updated `gradle.properties` to bump the snapshot version for all service packages and modules:
- `api_salesdistrict_srvVersion`
- `api_salesorganization_srvVersion`
- `api_sales_order_srvVersion`
- `api_sd_sa_soldtopartydetnVersion`
- `salesarea_0001Version`
- `api_sd_incoterms_srvVersion`
- `api_sales_inquiry_srvVersion`
- `api_sales_quotation_srvVersion`
- `api_sales_order_simulation_srvVersion`
- `ce_salesorder_0001Version`

The root project version property was also updated to 2.1.0-SNAPSHOT to maintain consistency across the multi-package repository structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-sap.s4hana.sales/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->